### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/yequ/ad3004cb-6916-4408-8b74-4146b2ff6159/84c09bbc-2da7-4280-aad4-e2ed3921824c/_apis/work/boardbadge/6705a027-9bf4-408d-89d3-1e29ab08829d)](https://dev.azure.com/yequ/ad3004cb-6916-4408-8b74-4146b2ff6159/_boards/board/t/84c09bbc-2da7-4280-aad4-e2ed3921824c/Microsoft.RequirementCategory)
 # troy
 A Nice Caddy with Trojan Launcher


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/yequ/ad3004cb-6916-4408-8b74-4146b2ff6159/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.